### PR TITLE
Migrate away from installing deprecated driver

### DIFF
--- a/code/python/example.py
+++ b/code/python/example.py
@@ -1,4 +1,4 @@
-# pip3 install neo4j-driver
+# pip3 install neo4j
 # python3 example.py
 
 from neo4j import GraphDatabase, basic_auth


### PR DESCRIPTION
With 6.0 the package `neo4j-driver` will receive no further updates.

If we can't agree on any other changes to the examples, please consider not pushing more users into something deprecated. This will just create avoidable extra pain when we finally pull the plug on `neo4j-driver`.